### PR TITLE
Chore: update engine version to 2.9.1

### DIFF
--- a/aurora-rust-sdk/aurora-sdk-integration-tests/Cargo.toml
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/Cargo.toml
@@ -6,13 +6,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb" }
-aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb" }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb" }
-aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb" }
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb" }
+aurora-engine = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["std", "borsh-compat"] }
+aurora-engine-precompiles = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["std", "borsh-compat"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["std", "borsh-compat"] }
+aurora-engine-transactions = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b" }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["std", "borsh-compat"] }
 base64 = "0.21"
-borsh = "0.9"
 ethabi = "18"
 hex = "0.4"
 near-sdk = "4.1.0"

--- a/aurora-rust-sdk/aurora-sdk-integration-tests/src/aurora_engine/mod.rs
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/src/aurora_engine/mod.rs
@@ -1,7 +1,7 @@
 use crate::wnear::Wnear;
 use aurora_engine::parameters::{
-    CallArgs, DeployErc20TokenArgs, FunctionCallArgsV2, SubmitResult, TransactionStatus,
-    ViewCallArgs,
+    CallArgs, DeployErc20TokenArgs, FunctionCallArgsV2, NewCallArgs, NewCallArgsV2, SubmitResult,
+    TransactionStatus, ViewCallArgs,
 };
 use aurora_engine_types::{
     types::{Address, Wei},
@@ -35,12 +35,11 @@ pub async fn deploy_latest(worker: &Worker<Sandbox>) -> anyhow::Result<AuroraEng
         .create_tla_and_deploy(AURORA_ACCOUNT_ID.parse().unwrap(), sk, &wasm)
         .await?
         .into_result()?;
-    let new_args = aurora_engine::parameters::NewCallArgs {
+    let new_args = NewCallArgs::V2(NewCallArgsV2 {
         chain_id: aurora_engine_types::types::u256_to_arr(&TESTNET_CHAIN_ID.into()),
         owner_id: contract.id().as_ref().parse().unwrap(),
-        bridge_prover_id: contract.id().as_ref().parse().unwrap(),
         upgrade_delay_blocks: 0,
-    };
+    });
 
     // Initialize main contract
     contract

--- a/aurora-rust-sdk/aurora-sdk-integration-tests/src/aurora_engine/repo.rs
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/src/aurora_engine/repo.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use tokio::sync::Mutex;
 
-pub const LATEST_ENGINE_VERSION: &str = "2.8.1";
+pub const LATEST_ENGINE_VERSION: &str = "2.9.1";
 const TARGET: &str = "target";
 const ENGINE_PATH: &str = "aurora-engine";
 /// A lock to prevent multiple tests from modifying the aurora-engine repo at the same time.

--- a/aurora-rust-sdk/aurora-sdk/Cargo.toml
+++ b/aurora-rust-sdk/aurora-sdk/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb", default-features = false, features = ["contracts-std", "impl-serde"] }
-aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "5416ffc790f6c98421756f9d06993be4a55875bb", default-features = false, features = ["contract"] }
+aurora-engine-types = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["contracts-std", "impl-serde", "borsh-compat"] }
+aurora-engine-sdk = { git = "https://github.com/aurora-is-near/aurora-engine.git", rev = "cd4e046699a72cab0adf02bb5d7c47783732cf1b", default-features = false, features = ["contract", "borsh-compat"] }
 ethabi = { version = "18", default-features = false }
 hex = "0.4"
 near-sdk = { version = "4.1", features = ["abi"] }


### PR DESCRIPTION
Updates the SDK to use the latest engine version.

Related to https://github.com/aurora-is-near/aurora-engine/pull/767 (the SDK will not compile without that change).