### PR TITLE
Pass extra arguments to `forge_build`

### DIFF
--- a/aurora-rust-sdk/aurora-sdk-integration-tests/Cargo.toml
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aurora-sdk-integration-tests"
 description = "Rust library for writing integration tests for NEAR smart contracts interacting with the Aurora Engine."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/aurora-rust-sdk/aurora-sdk-integration-tests/src/utils/forge.rs
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/src/utils/forge.rs
@@ -60,13 +60,13 @@ pub async fn forge_build_with_args<P: AsRef<Path>>(
     root_path: P,
     libraries: &[String],
     contract_output_path: &[&str],
-    extra_args: &[String],
+    extra_args: &[&str],
 ) -> anyhow::Result<ContractConstructor> {
     let _guard = FORGE_LOCK.lock().await;
     let contracts_path = root_path.as_ref();
     let args = std::iter::once("build")
         .chain(libraries.iter().flat_map(|x| ["--libraries", x]))
-        .chain(extra_args.iter().map(|s| s.as_ref()));
+        .chain(extra_args.iter().copied());
 
     let output = Command::new("forge")
         .current_dir(contracts_path)

--- a/aurora-rust-sdk/aurora-sdk-integration-tests/src/utils/forge.rs
+++ b/aurora-rust-sdk/aurora-sdk-integration-tests/src/utils/forge.rs
@@ -53,9 +53,21 @@ pub async fn forge_build<P: AsRef<Path>>(
     libraries: &[String],
     contract_output_path: &[&str],
 ) -> anyhow::Result<ContractConstructor> {
+    forge_build_with_args(root_path, libraries, contract_output_path, &[]).await
+}
+
+pub async fn forge_build_with_args<P: AsRef<Path>>(
+    root_path: P,
+    libraries: &[String],
+    contract_output_path: &[&str],
+    extra_args: &[String],
+) -> anyhow::Result<ContractConstructor> {
     let _guard = FORGE_LOCK.lock().await;
     let contracts_path = root_path.as_ref();
-    let args = std::iter::once("build").chain(libraries.iter().flat_map(|x| ["--libraries", x]));
+    let args = std::iter::once("build")
+        .chain(libraries.iter().flat_map(|x| ["--libraries", x]))
+        .chain(extra_args.iter().map(|s| s.as_ref()));
+
     let output = Command::new("forge")
         .current_dir(contracts_path)
         .args(args)

--- a/aurora-rust-sdk/rust-toolchain
+++ b/aurora-rust-sdk/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.69.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Added new method `forge_build_with_args` to be able to pass extra arguments eg. `--optimizer-runs`